### PR TITLE
Only copy music url when share is pressed

### DIFF
--- a/src/lib/components/ListItem/ListItem.svelte
+++ b/src/lib/components/ListItem/ListItem.svelte
@@ -91,28 +91,20 @@
 			icon: 'share',
 			action: async () => {
 				let shareData = {
-					title: item.title,
-					text: `Listen to ${item.title} on Beatbump`,
 					url: `https://beatbump.ml/listen?id=${item.videoId}`
 				};
 				if (item.endpoint?.pageType?.includes('MUSIC_PAGE_TYPE_PLAYLIST')) {
 					shareData = {
-						title: item.title,
-						text: `Listen to ${item.title} on Beatbump`,
 						url: `https://beatbump.ml/playlist/${item.endpoint?.browseId}`
 					};
 				}
 				if (item.endpoint?.pageType?.includes('MUSIC_PAGE_TYPE_ALBUM')) {
 					shareData = {
-						title: item.title,
-						text: `Listen to ${item.title} on Beatbump`,
 						url: `https://beatbump.ml/release?id=${item.endpoint?.browseId}`
 					};
 				}
 				if (item.endpoint?.pageType?.includes('MUSIC_PAGE_TYPE_ARTIST')) {
 					shareData = {
-						title: item.title,
-						text: `${item.title} on Beatbump`,
 						url: `https://beatbump.ml/artist/${item.endpoint?.browseId}`
 					};
 				}


### PR DESCRIPTION
When pressing share it's a hassle to paste the url into a browser, and when sharing a song with a friend I don't want this showing up, Spotify doesn't include anything besides the song url when a song is shared aswell, also make sure to check this pull request and make sure I didn't mess anything up, thanks!