### PR TITLE
Fix EU formatting of search responses.

### DIFF
--- a/src/routes/api/_modules/parsers/search.ts
+++ b/src/routes/api/_modules/parsers/search.ts
@@ -244,6 +244,14 @@ function parseSearchResult(data, cont, filter?) {
 	let didYouMean
 	let ctx
 
+	// Fix EU reponse formatting
+	for (let i = 0; i < data.length; i++){
+		if (data[i].hasOwnProperty('itemSectionRenderer'))
+		{
+			data.splice(i, 1);
+		}
+	}
+
 	if (cont) {
 		ctx = [data]
 	} else {

--- a/src/routes/api/search.json.ts
+++ b/src/routes/api/search.json.ts
@@ -257,6 +257,14 @@ function parseSearchResult(data, cont, filter?) {
 
 	let didYouMean
 	let ctx
+	
+	// Fix EU reponse formatting
+	for (let i = 0; i < data.length; i++){
+		if (data[i].hasOwnProperty('itemSectionRenderer'))
+		{
+			data.splice(i, 1);
+		}
+	}
 
 	if (cont) {
 		ctx = [data]


### PR DESCRIPTION
After opening the issue #81 and examining the problem I implemented a quick fix for the weird EU formatting of search responses.
Tested it on my dev instance and it works great.