### PR TITLE
Bigger image for the player

### DIFF
--- a/app/src/lib/components/Player/Fullscreen.svelte
+++ b/app/src/lib/components/Player/Fullscreen.svelte
@@ -681,6 +681,9 @@
 		@media screen and (max-width: 719px) {
 			max-height: 28vh;
 		}
+		@media screen and (min-width: 1800) {
+			max-height: 45vh;
+		}
 	}
 	.thumbnail {
 		position: relative;

--- a/app/src/lib/components/Player/Fullscreen.svelte
+++ b/app/src/lib/components/Player/Fullscreen.svelte
@@ -681,7 +681,7 @@
 		@media screen and (max-width: 719px) {
 			max-height: 28vh;
 		}
-		@media screen and (min-width: 1800) {
+		@media screen and (min-width: 1800px) {
 			max-height: 45vh;
 		}
 	}


### PR DESCRIPTION
Hello,
Small PR to increase the maximum height on big screens, see the screenshots below:
<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/92821484/218270829-703266bf-af6b-4728-8a88-364d5313f814.png" width="800">
	<td><img src="https://user-images.githubusercontent.com/92821484/218271101-7c06b2e7-8b05-4756-85cd-3d49406ab6ef.png" width="800">
<tr>
	<td><img src="https://user-images.githubusercontent.com/92821484/218271107-ba7da248-efc9-4415-9370-2799966cd222.png" width="800">
	<td><img src="https://user-images.githubusercontent.com/92821484/218271113-9955c009-56eb-4c27-8382-03e2c508b38f.png" width="800">
</table>

As a daily user of Beatbump, I want to thank you a lot for all your efforts!