### PR TITLE
Urlize "Show All" link on search pages.

### DIFF
--- a/app/src/routes/search/[slug]/+page.svelte
+++ b/app/src/routes/search/[slug]/+page.svelte
@@ -104,7 +104,9 @@
 						<div class="show-more">
 							<a
 								data-testid=""
-								href={`${$page.params.slug}?filter=${result.header.title.replace(/\s/g, "_").toLowerCase()}`}
+								href={`${encodeURIComponent($page.params.slug)}?filter=${result.header.title
+									.replace(/\s/g, "_")
+									.toLowerCase()}`}
 								class="link secondary">Show All</a
 							>
 						</div>


### PR DESCRIPTION
Currently, if a search has a forward slash in it (e.g. [graphite/diamond](https://beatbump.ml/search/graphite%2Fdiamond?filter=all)), the "Show All" links will 404.

