### PR TITLE
Fix songs not playing due to YouTube player api returning 400

### DIFF
--- a/app/src/routes/api/_lib/types.ts
+++ b/app/src/routes/api/_lib/types.ts
@@ -1,6 +1,6 @@
 export interface Client {
 	clientName?: "ANDROID" | "WEB_REMIX" | "IOS";
-	clientVersion?: "17.13.3" | "1.20220404.01.00" | "16.20";
+	clientVersion?: "18.11.34" | "1.20220404.01.00" | "16.20";
 	utcOffsetMinutes?: number;
 	visitorData?: string;
 	gl?: string;

--- a/app/src/routes/api/v1/player.json/+server.ts
+++ b/app/src/routes/api/v1/player.json/+server.ts
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	try {
 		const response = await buildAPIRequest("player", {
 			context: {
-				client: { clientName: "IOS", clientVersion: "17.13.3", hl: "en" },
+				client: { clientName: "IOS", clientVersion: "18.11.34", hl: "en" },
 			},
 			params: { videoId, playlistId, params: playerParams, racyCheckOk: true, contentCheckOk: true },
 		});


### PR DESCRIPTION
Player API returns 400 precondition failed.
Fix is to bump the ios version similar to the fix that was done here - https://github.com/yt-dlp/yt-dlp/commit/413d3675804599bc8fe419c19e36490fd8f0b30f 