### PR TITLE
chore: remove no-op settings

### DIFF
--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -46,14 +46,6 @@ const config = {
 			$env: path.resolve("./src/env.ts"),
 		},
 		prerender: { concurrency: 3 },
-		files: {
-			assets: "static",
-			lib: "src/lib",
-			routes: "src/routes",
-			serviceWorker: "src/service-worker",
-			appTemplate: "src/app.html",
-			hooks: { server: "src/hooks.server" },
-		},
 		version: { pollInterval: 600000 },
 	},
 	onwarn(warning, defaultHandler) {


### PR DESCRIPTION
These look like they're all setting the values to the defaults. We're about to deprecate them, so removing them will both simplify things and save you a deprecation warning